### PR TITLE
Update themes.md

### DIFF
--- a/docs/content/documentation/themes.md
+++ b/docs/content/documentation/themes.md
@@ -22,11 +22,11 @@ theme = (
 | `body-box-args` | [dictionary] | | Arguments given to the body box. |
 | `body-box-args-with-title` | [dictionary] | | Arguments given to the body box when a title is present. This dictionary is optional. Leaving  |
 | `body-box-function` | [function] | | Arguments given to the body box. |
-| `body-text-args` | [dictionary] | | Text related arguments given to the body box. |
+| `body-text-args` | [dictionary] | | Text-related arguments given to the body box. |
 | `heading-box-args` | [dictionary] | | Arguments given to the heading box. |
 | `heading-box-args-with-body` | [dictionary] | | Arguments given to the body box. |
 | `heading-box-function` | [function] | | Fuctions given to the heading box. |
-| `heading-text-args` | [dictionary] | | Text related arguments given to the heading box. |
+| `heading-text-args` | [dictionary] | | Text-related arguments given to the heading box. |
 
 
 ### `heading-text-args` & `body-text-args`
@@ -34,15 +34,15 @@ Takes arguments to alter heading or body text. for all possible arguments see: [
 
 ```typst
 "heading-text-args": (
-fill: rgb("#FFFFFF"),
-font: "Lora",
+    fill: rgb("#FFFFFF"),
+    font: "Lora",
 )
 ```
 This would ensure the heading text color is white (#FFFFFF) and the font family is set to 'Lora'.
 
 ```typst
 "body-text-args": (
-font: ("Ubuntu", "Source Han Sans"),
+    font: ("Ubuntu", "Source Han Sans"),
 )
 ```
 This would set body font family to `Ubuntu` with `Source Han Sans` as fallback.

--- a/docs/content/documentation/themes.md
+++ b/docs/content/documentation/themes.md
@@ -19,13 +19,33 @@ theme = (
 ```
 | Argument | Type | Default Value | Description |
 | --- | --- | --- | --- |
-| `body-box-args` | [dictionary] | | Arguemtns given to the body box. |
-| `body-box-args-with-title` | [dictionary] | | Arguemtns given to the body box when a title is present. This dictionary is optional. Leaving  |
-| `body-box-function` | [function] | | Arguemtns given to the body box. |
-| `heading-box-args` | [dictionary] | | Arguemtns given to the body box. |
-| `heading-box-args-with-body` | [dictionary] | | Arguemtns given to the body box. |
-| `heading-box-function` | [function] | | Arguemtns given to the body box. |
+| `body-box-args` | [dictionary] | | Arguments given to the body box. |
+| `body-box-args-with-title` | [dictionary] | | Arguments given to the body box when a title is present. This dictionary is optional. Leaving  |
+| `body-box-function` | [function] | | Arguments given to the body box. |
+| `body-text-args` | [dictionary] | | Text related arguments given to the body box. |
+| `heading-box-args` | [dictionary] | | Arguments given to the heading box. |
+| `heading-box-args-with-body` | [dictionary] | | Arguments given to the body box. |
+| `heading-box-function` | [function] | | Fuctions given to the heading box. |
+| `heading-text-args` | [dictionary] | | Text related arguments given to the heading box. |
 
+
+### `heading-text-args` & `body-text-args`
+Takes arguments to alter heading or body text. for all possible arguments see: [Text](https://typst.app/docs/reference/text/text/)
+
+```typst
+"heading-text-args": (
+fill: rgb("#FFFFFF"),
+font: "Lora",
+)
+```
+This would ensure the heading text color is white (#FFFFFF) and the font family is set to 'Lora'.
+
+```typst
+"body-text-args": (
+font: ("Ubuntu", "Source Han Sans"),
+)
+```
+This would set body font family to `Ubuntu` with `Source Han Sans` as fallback.
 
 ## Updating a Theme
 ```typst


### PR DESCRIPTION
fixed type in table (Arguemtns > Arguments)

added rows for heading-text-args and body-text-args

added examples for both heading-text-args and body-text-args.

Open to any changes regarding the wording or examples.