### PR TITLE
Added TU Graz theme

### DIFF
--- a/themes.typ
+++ b/themes.typ
@@ -71,6 +71,41 @@
     )
 )
 
+#let tug = (
+  "body-box-args": (
+    inset: 1em,
+    width: 100%,
+    stroke: none,
+    fill: rgb("#eeece1"),
+  ),
+  "body-text-args": (
+    font: ("Arial", "Libertinus Serif"),
+  ),
+  "heading-box-args": (
+    inset: (left: 1em, rest: 0.6em),
+    width: 100%,
+    fill: rgb("#e4154b"),
+    stroke: none,
+  ),
+  "heading-text-args": (
+    fill: white,
+    font: ("Arial", "Libertinus Serif"),
+  ),
+  "title-box-args": (
+    inset: (left: 2em, rest: 1em),
+    fill: white,
+    stroke: (
+      left: 1em + rgb("#e4154b"),
+    ),
+    outset: (left: -0.5em),
+  ),
+  "title-text-args": (
+    fill: black,
+    font: ("Arial", "Libertinus Serif"),
+  ),
+)
+
+
 #let update-theme(..args) = {
     for (arg, val) in args.named() {
         _state-poster-theme.update(pt => {


### PR DESCRIPTION
Adding theme for [TU Graz](https://tugraz.at), which is based on [definitely-not-isec-slides](https://typst.app/universe/package/definitely-not-isec-slides). This template is fully compatible with TU Graz corporate identity, but not officially recognised.