### PR TITLE
Respect explicit body-text-args.size

### DIFF
--- a/boxes.typ
+++ b/boxes.typ
@@ -198,7 +198,8 @@
 
   // Determine the size of the body
   let body-size = pl.at("body-size", default: body-size)
-  if body-size != none {
+  let body-text-args-keys = body-text-args.keys()
+  if body-size != none and not body-text-args-keys.contains("size") {
     body-text-args.insert("size", body-size)
   }
 


### PR DESCRIPTION
  ## Summary

  Fixes an issue where `body-text-args: (size: 1pt)` did not take effect because `body-size` was always inserted into `body-text-args` afterward.

  ## Example

  Before this fix, the explicit `size: 1pt` was overwritten:

  ```typst
  #body-box(
    body-text-args: (size: 1pt),
  )[
    Small body text
  ]
```

  After this fix, body-text-args.size is preserved unless body-size is used instead.

  ## Changes

  - Check whether body-text-args already contains size
  - Only apply body-size when no explicit body-text-args.size is provided